### PR TITLE
skip NaNs to preseve gaps in data

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,9 @@ function normalize (arr, dim, bounds) {
 		else {
 			var range = max - min
 			for (i = offset; i < l; i+=dim) {
-				arr[i] = range === 0 ? .5 : (arr[i] - min) / range
+				if (!isNaN(arr[i])) {
+					arr[i] = range === 0 ? .5 : (arr[i] - min) / range
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This can help fix https://github.com/gl-vis/regl-line2d/issues/43 as well as https://github.com/plotly/plotly.js/issues/3551

@dy 
cc: @etpinard 
